### PR TITLE
Add hierarchical clustering to digital twin and monitoring tools

### DIFF
--- a/examples/gaia_air/digital_twin_simulation.py
+++ b/examples/gaia_air/digital_twin_simulation.py
@@ -2,6 +2,8 @@ import numpy as np
 import dash
 from dash import dcc, html
 from dash.dependencies import Input, Output
+from scipy.cluster.hierarchy import dendrogram, linkage, fcluster
+import matplotlib.pyplot as plt
 
 class DigitalTwin:
     def __init__(self, model):
@@ -89,6 +91,16 @@ class DigitalTwin:
 
         return flagged_info
 
+    def hierarchical_clustering(self, data, method='ward'):
+        Z = linkage(data, method=method)
+        return Z
+
+    def plot_dendrogram(self, Z):
+        plt.figure(figsize=(10, 7))
+        plt.title("Dendrogram")
+        dendrogram(Z)
+        plt.show()
+
     def update_graphs(self, n_intervals):
         """
         Called every interval to:
@@ -99,6 +111,9 @@ class DigitalTwin:
         """
         simulated_data = self.simulate_data()
         flagged_info = self.analyze_data(simulated_data)
+
+        # Perform hierarchical clustering
+        Z = self.hierarchical_clustering(simulated_data)
 
         # Prepare the main simulation figure
         # For demonstration, plot the first two columns of the simulated data
@@ -135,6 +150,9 @@ class DigitalTwin:
             'layout': {'title': 'Flagged Correlation Events Over Time'}
         }
 
+        # Plot dendrogram
+        self.plot_dendrogram(Z)
+
         return figure_simulation, figure_flagged
 
     def visualize_results(self):
@@ -159,4 +177,3 @@ if __name__ == "__main__":
     # to push fresh sensor readings or updates.
 
     dt.visualize_results()
-

--- a/examples/gaia_air/monitoring_tools_usage.py
+++ b/examples/gaia_air/monitoring_tools_usage.py
@@ -4,6 +4,8 @@ import dash
 import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Input, Output
+from scipy.cluster.hierarchy import dendrogram, linkage, fcluster
+import matplotlib.pyplot as plt
 
 class MonitoringTools:
     def __init__(self):
@@ -37,8 +39,26 @@ class MonitoringTools:
             aggregated_data[source].append(data['value'])
         return aggregated_data
 
+    def hierarchical_clustering(self, data, method='ward'):
+        Z = linkage(data, method=method)
+        return Z
+
+    def plot_dendrogram(self, Z):
+        plt.figure(figsize=(10, 7))
+        plt.title("Dendrogram")
+        dendrogram(Z)
+        plt.show()
+
     def update_graph(self, n_intervals):
         aggregated_data = self.aggregate_telemetry()
+        data = np.array([values for values in aggregated_data.values()])
+
+        # Perform hierarchical clustering
+        Z = self.hierarchical_clustering(data)
+
+        # Plot dendrogram
+        self.plot_dendrogram(Z)
+
         figure = {
             'data': [
                 {'x': list(range(len(values))), 'y': values, 'type': 'line', 'name': source}


### PR DESCRIPTION
Add hierarchical clustering and dendrogram visualization to `digital_twin_simulation.py` and `monitoring_tools_usage.py`.

* **`digital_twin_simulation.py`**
  - Import `linkage`, `dendrogram`, and `fcluster` from `scipy.cluster.hierarchy` and `matplotlib.pyplot`.
  - Add `hierarchical_clustering` method to perform hierarchical clustering on sensor data.
  - Add `plot_dendrogram` method to visualize the dendrogram of hierarchical clustering.
  - Modify `update_graphs` method to include hierarchical clustering and dendrogram visualization.

* **`monitoring_tools_usage.py`**
  - Import `linkage`, `dendrogram`, and `fcluster` from `scipy.cluster.hierarchy` and `matplotlib.pyplot`.
  - Add `hierarchical_clustering` method to perform hierarchical clustering on telemetry data.
  - Add `plot_dendrogram` method to visualize the dendrogram of hierarchical clustering.
  - Modify `update_graph` method to include hierarchical clustering and dendrogram visualization.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Robbbo-T/Ampel360XWLRGA?shareId=XXXX-XXXX-XXXX-XXXX).