### PR TITLE
Add ATA chapter-based documentation for landing gear

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -39,3 +39,37 @@
 - **Risk Level:** High
 - **Status:** In Progress
 - **Technology Type:** Quantum Propulsion
+
+## ATA Chapter-Based Layout
+
+### Instructions:
+1. **ATA Chapter:** Specify the ATA chapter relevant to the issue.
+2. **Section:** Provide the section within the ATA chapter.
+3. **Sub-Section:** Provide the sub-section within the ATA chapter, if applicable.
+4. **Description:** Describe the issue or task related to the specified ATA chapter.
+
+### Example:
+- **ATA Chapter:** 32 - Landing Gear
+- **Section:** 32-10-00 - Main Landing Gear and Doors
+- **Sub-Section:** 32-10-10 - Main Landing Gear Strut
+- **Description:** Inspection and maintenance of the main landing gear strut.
+
+## Creating Issues for Specific ATA Chapters
+
+### Instructions:
+1. **Title:** Provide a clear and concise title for the issue.
+2. **ATA Chapter:** Specify the ATA chapter relevant to the issue.
+3. **Section:** Provide the section within the ATA chapter.
+4. **Sub-Section:** Provide the sub-section within the ATA chapter, if applicable.
+5. **Description:** Describe the issue or task related to the specified ATA chapter.
+6. **Milestone:** Assign the issue to a relevant milestone.
+7. **Labels:** Apply relevant labels to categorize the issue.
+
+### Example:
+- **Title:** Main Landing Gear Strut Inspection
+- **ATA Chapter:** 32 - Landing Gear
+- **Section:** 32-10-00 - Main Landing Gear and Doors
+- **Sub-Section:** 32-10-10 - Main Landing Gear Strut
+- **Description:** Conduct inspection and maintenance of the main landing gear strut.
+- **Milestone:** Landing Gear Maintenance
+- **Labels:** Inspection, Maintenance, Landing Gear

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,6 +22,10 @@ jobs:
           pip install mkdocs-material
           # Install any other MkDocs plugins you use
 
+      - name: Build MkDocs site
+        run: |
+          mkdocs build
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/app.py
+++ b/app.py
@@ -176,6 +176,10 @@ def create_directories_and_files(base_path, structure):
             print(f"Created directory: {dir_path}")
             create_directories_and_files(dir_path, value)
 
+@app.route('/docs/<path:filename>')
+def serve_documentation(filename):
+    return send_from_directory('docs', filename)
+
 if __name__ == "__main__":
     input_text = """
 2.1 AMPEL360XWLRGA (Advanced Aircraft

--- a/docs/32-00-00_Tren_de_Aterrizaje.md
+++ b/docs/32-00-00_Tren_de_Aterrizaje.md
@@ -1,0 +1,51 @@
+# 32-00-00 Tren de Aterrizaje (General)
+
+## Descripción del Sistema de Tren de Aterrizaje
+
+El sistema de tren de aterrizaje es un componente crítico de la aeronave, diseñado para soportar el peso de la aeronave durante el despegue, aterrizaje y rodaje en tierra. Este sistema incluye varios subsistemas y componentes que trabajan en conjunto para proporcionar estabilidad, maniobrabilidad y seguridad.
+
+### Componentes Principales
+
+1. **Tren de Aterrizaje Principal (MLG):**
+   - Soporta la mayor parte del peso de la aeronave.
+   - Incluye amortiguadores, ruedas y frenos.
+
+2. **Tren de Aterrizaje de Nariz (NLG):**
+   - Proporciona dirección durante el rodaje.
+   - Incluye amortiguadores y ruedas.
+
+3. **Sistemas de Control del Tren de Aterrizaje:**
+   - Mecanismos y sensores que controlan la extensión y retracción del tren de aterrizaje.
+   - Interfaz con el cockpit y circuitos electrónicos.
+
+4. **Sistema de Frenado del Tren de Aterrizaje:**
+   - Frenos, discos y actuadores hidráulicos.
+   - Monitoreo de desgaste y programas de mantenimiento.
+
+5. **Sistema de Retracción del Tren de Aterrizaje:**
+   - Bomba hidráulica y brazos de retracción.
+   - Secuencia de retracción y procedimientos de ajuste.
+
+6. **Puertas del Tren de Aterrizaje:**
+   - Tipos de puertas (principal, nariz), bisagras y actuadores.
+   - Ajustes, tolerancias y alineación.
+
+7. **Indicadores y Sistemas de Alerta del Tren de Aterrizaje:**
+   - Luces de tren, alarmas y señales de posición.
+   - Diagnóstico y resolución de fallos en alertas.
+
+8. **Sistemas Hidráulicos para el Tren de Aterrizaje:**
+   - Líneas y válvulas hidráulicas dedicadas al tren.
+   - Depósitos, purga y mantenimiento de fluidos.
+
+9. **Sistemas de Lubricación del Tren de Aterrizaje:**
+   - Puntos de lubricación, tipos de lubricantes e intervalos.
+   - Prácticas estándar para reducir desgaste.
+
+10. **Sistemas de Respaldo y Emergencia del Tren de Aterrizaje:**
+    - Mecanismos de liberación emergente.
+    - Procedimientos en caso de fallo hidráulico.
+
+11. **FIN, Consumibles y Expendables:**
+    - Functional Item Numbers (FIN), partes de uso único o consumibles.
+    - Identificación de repuestos y documentación de inventario.

--- a/docs/32-10-00_Tren_de_Aterrizaje_Principal_y_Puertas.md
+++ b/docs/32-10-00_Tren_de_Aterrizaje_Principal_y_Puertas.md
@@ -1,0 +1,114 @@
+# 32-10-00 Tren de Aterrizaje Principal y Puertas
+
+## Descripción Detallada del Tren Principal (MLG)
+
+El tren de aterrizaje principal (MLG) es un componente esencial del sistema de tren de aterrizaje de la aeronave. Está diseñado para soportar la mayor parte del peso de la aeronave durante el despegue, aterrizaje y rodaje. El MLG incluye varios subsistemas y componentes que trabajan en conjunto para proporcionar estabilidad, maniobrabilidad y seguridad.
+
+### Componentes Principales del MLG
+
+1. **Amortiguadores:**
+   - Absorben y disipan la energía del impacto durante el aterrizaje.
+   - Proporcionan una conducción suave durante el rodaje.
+
+2. **Ruedas y Neumáticos:**
+   - Soportan el peso de la aeronave y proporcionan tracción durante el despegue y aterrizaje.
+   - Diseñados para resistir altas cargas y velocidades.
+
+3. **Frenos:**
+   - Proporcionan la capacidad de detener la aeronave de manera segura.
+   - Incluyen discos de freno, actuadores hidráulicos y sistemas de monitoreo de desgaste.
+
+4. **Estructura del Tren de Aterrizaje:**
+   - Soporta todos los componentes del MLG.
+   - Fabricada con materiales de alta resistencia para soportar cargas extremas.
+
+## Mantenimiento, Inspección, Partes y Referencias
+
+### Mantenimiento del MLG
+
+El mantenimiento del tren de aterrizaje principal es crucial para garantizar su funcionamiento seguro y eficiente. Las tareas de mantenimiento incluyen inspecciones regulares, reemplazo de componentes desgastados y ajustes necesarios.
+
+1. **Inspecciones Regulares:**
+   - Inspección visual de los componentes del MLG.
+   - Verificación de la integridad estructural y funcionalidad de los amortiguadores, ruedas, frenos y estructura.
+
+2. **Reemplazo de Componentes:**
+   - Sustitución de neumáticos desgastados.
+   - Reemplazo de discos de freno y actuadores hidráulicos según sea necesario.
+
+3. **Ajustes y Calibraciones:**
+   - Ajuste de la presión de los neumáticos.
+   - Calibración de los sistemas de monitoreo de desgaste de los frenos.
+
+### Partes y Referencias
+
+1. **Amortiguadores:**
+   - P/N: AMORT-MLG-001
+   - Fabricante: LandingGear Innovations
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/amortiguadores)
+
+2. **Ruedas y Neumáticos:**
+   - P/N: RUEDA-MLG-002
+   - Fabricante: AeroTires Inc.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/ruedas)
+
+3. **Frenos:**
+   - P/N: FRENO-MLG-003
+   - Fabricante: BrakeTech Systems
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/frenos)
+
+4. **Estructura del Tren de Aterrizaje:**
+   - P/N: ESTRUCT-MLG-004
+   - Fabricante: StrongStructures Ltd.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/estructura)
+
+## Puertas del Tren de Aterrizaje
+
+Las puertas del tren de aterrizaje son componentes críticos que protegen el tren de aterrizaje cuando está retraído y mejoran la aerodinámica de la aeronave. Incluyen varios subsistemas y componentes que aseguran su funcionamiento correcto.
+
+### Componentes Principales de las Puertas del Tren de Aterrizaje
+
+1. **Puertas Principales:**
+   - Cubren el tren de aterrizaje principal cuando está retraído.
+   - Fabricadas con materiales compuestos ligeros y resistentes.
+
+2. **Bisagras y Actuadores:**
+   - Permiten la apertura y cierre de las puertas.
+   - Incluyen actuadores hidráulicos y bisagras de alta resistencia.
+
+3. **Sistemas de Cierre y Sellado:**
+   - Aseguran que las puertas permanezcan cerradas durante el vuelo.
+   - Proporcionan un sellado hermético para mejorar la aerodinámica.
+
+### Mantenimiento de las Puertas del Tren de Aterrizaje
+
+El mantenimiento de las puertas del tren de aterrizaje es esencial para garantizar su funcionamiento correcto y la seguridad de la aeronave. Las tareas de mantenimiento incluyen inspecciones regulares, lubricación de componentes y ajustes necesarios.
+
+1. **Inspecciones Regulares:**
+   - Inspección visual de las puertas, bisagras y actuadores.
+   - Verificación de la integridad estructural y funcionalidad de los sistemas de cierre y sellado.
+
+2. **Lubricación de Componentes:**
+   - Aplicación de lubricantes adecuados a las bisagras y actuadores.
+   - Verificación de la lubricación adecuada para asegurar un funcionamiento suave.
+
+3. **Ajustes y Calibraciones:**
+   - Ajuste de la alineación de las puertas.
+   - Calibración de los actuadores hidráulicos para asegurar un funcionamiento preciso.
+
+### Partes y Referencias
+
+1. **Puertas Principales:**
+   - P/N: PUERTA-MLG-005
+   - Fabricante: AeroDoors Inc.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/puertas)
+
+2. **Bisagras y Actuadores:**
+   - P/N: BISAGRA-MLG-006
+   - Fabricante: HingeTech Solutions
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/bisagras)
+
+3. **Sistemas de Cierre y Sellado:**
+   - P/N: SELLO-MLG-007
+   - Fabricante: SealSystems Ltd.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/sellos)

--- a/docs/32-100-00_Sistemas_de_Respaldo_y_Emergencia_del_Tren_de_Aterrizaje.md
+++ b/docs/32-100-00_Sistemas_de_Respaldo_y_Emergencia_del_Tren_de_Aterrizaje.md
@@ -1,0 +1,69 @@
+# 32-100-00 Sistemas de Respaldo y Emergencia del Tren de Aterrizaje
+
+## Descripción de los Sistemas de Respaldo y Emergencia
+
+Los sistemas de respaldo y emergencia del tren de aterrizaje son componentes críticos diseñados para garantizar la seguridad de la aeronave en caso de fallos en el sistema principal. Estos sistemas proporcionan mecanismos alternativos para la extensión y retracción del tren de aterrizaje, asegurando que la aeronave pueda aterrizar de manera segura incluso en situaciones de emergencia.
+
+### Mecanismos de Liberación Emergente
+
+1. **Sistema de Liberación Manual:**
+   - Permite la extensión manual del tren de aterrizaje en caso de fallo hidráulico o eléctrico.
+   - Incluye palancas y mecanismos de liberación que pueden ser operados por la tripulación de vuelo.
+
+2. **Sistema de Liberación por Gravedad:**
+   - Utiliza la gravedad para extender el tren de aterrizaje en caso de fallo del sistema hidráulico.
+   - Diseñado para funcionar automáticamente cuando se detecta una pérdida de presión hidráulica.
+
+3. **Sistema de Liberación por Nitrógeno:**
+   - Utiliza cilindros de nitrógeno presurizado para forzar la extensión del tren de aterrizaje.
+   - Activado automáticamente o manualmente en caso de emergencia.
+
+### Procedimientos en Caso de Fallo Hidráulico
+
+En caso de fallo hidráulico, es esencial seguir procedimientos específicos para garantizar la extensión segura del tren de aterrizaje. Estos procedimientos incluyen la activación de los sistemas de respaldo y la verificación de la extensión completa del tren de aterrizaje.
+
+1. **Activación del Sistema de Liberación Manual:**
+   - Localizar y operar las palancas de liberación manual según el manual de operaciones.
+   - Verificar visualmente la extensión completa del tren de aterrizaje.
+
+2. **Activación del Sistema de Liberación por Gravedad:**
+   - Confirmar la pérdida de presión hidráulica.
+   - Permitir que el sistema de liberación por gravedad extienda el tren de aterrizaje automáticamente.
+   - Verificar visualmente la extensión completa del tren de aterrizaje.
+
+3. **Activación del Sistema de Liberación por Nitrógeno:**
+   - Activar el sistema de liberación por nitrógeno manualmente si es necesario.
+   - Verificar visualmente la extensión completa del tren de aterrizaje.
+
+### Mantenimiento y Pruebas Funcionales
+
+El mantenimiento regular y las pruebas funcionales de los sistemas de respaldo y emergencia son esenciales para asegurar su fiabilidad y disponibilidad en situaciones de emergencia.
+
+1. **Inspección Visual:**
+   - Revisar visualmente todos los componentes de los sistemas de respaldo y emergencia.
+   - Buscar signos de desgaste, daños o fugas.
+
+2. **Pruebas de Operación:**
+   - Realizar pruebas de activación de los sistemas de liberación manual, por gravedad y por nitrógeno.
+   - Verificar el funcionamiento correcto de todos los mecanismos de liberación.
+
+3. **Mantenimiento Preventivo:**
+   - Reemplazar componentes críticos según el programa de mantenimiento preventivo.
+   - Asegurar que todos los sistemas estén en condiciones óptimas de operación.
+
+### Partes y Referencias
+
+1. **Sistema de Liberación Manual:**
+   - P/N: LIB-MAN-001
+   - Fabricante: SafetySystems Inc.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/liberacion_manual)
+
+2. **Sistema de Liberación por Gravedad:**
+   - P/N: LIB-GRAV-002
+   - Fabricante: GravityTech Ltd.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/liberacion_gravedad)
+
+3. **Sistema de Liberación por Nitrógeno:**
+   - P/N: LIB-NITRO-003
+   - Fabricante: NitrogenSystems Co.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/liberacion_nitrogeno)

--- a/docs/32-110-00_FIN_Consumibles_y_Expendables.md
+++ b/docs/32-110-00_FIN_Consumibles_y_Expendables.md
@@ -1,0 +1,93 @@
+# 32-110-00 FIN, Consumibles y Expendables
+
+## Functional Item Numbers (FIN)
+
+Los Functional Item Numbers (FIN) son identificadores únicos asignados a componentes específicos del tren de aterrizaje. Estos números permiten una fácil identificación y seguimiento de los componentes a lo largo de su ciclo de vida.
+
+### Lista de FIN
+
+1. **FIN-001:**
+   - **Descripción:** Amortiguador del tren de aterrizaje principal.
+   - **Fabricante:** LandingGear Innovations.
+   - **Manual de Mantenimiento:** [Enlace al Manual](https://example.com/manuales/amortiguadores).
+
+2. **FIN-002:**
+   - **Descripción:** Rueda del tren de aterrizaje de nariz.
+   - **Fabricante:** AeroTires Inc.
+   - **Manual de Mantenimiento:** [Enlace al Manual](https://example.com/manuales/ruedas).
+
+3. **FIN-003:**
+   - **Descripción:** Actuador hidráulico del sistema de control del tren de aterrizaje.
+   - **Fabricante:** HydroActuators Ltd.
+   - **Manual de Mantenimiento:** [Enlace al Manual](https://example.com/manuales/actuadores).
+
+## Consumibles
+
+Los consumibles son materiales y componentes que se utilizan durante el mantenimiento y operación del tren de aterrizaje y que deben ser reemplazados periódicamente.
+
+### Lista de Consumibles
+
+1. **Aceite Hidráulico:**
+   - **Descripción:** Aceite utilizado en el sistema hidráulico del tren de aterrizaje.
+   - **Fabricante:** HydroLubricants.
+   - **Intervalo de Reemplazo:** Cada 6 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.
+
+2. **Grasa de Lubricación:**
+   - **Descripción:** Grasa utilizada para lubricar los componentes móviles del tren de aterrizaje.
+   - **Fabricante:** LubeTech.
+   - **Intervalo de Reemplazo:** Cada 3 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.
+
+3. **Sellante:**
+   - **Descripción:** Sellante utilizado para asegurar la estanqueidad de los componentes del tren de aterrizaje.
+   - **Fabricante:** SealSystems Ltd.
+   - **Intervalo de Reemplazo:** Cada 12 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.
+
+## Expendables
+
+Los expendables son componentes de uso único que deben ser reemplazados después de cada uso o después de un período específico de tiempo.
+
+### Lista de Expendables
+
+1. **Filtro Hidráulico:**
+   - **Descripción:** Filtro utilizado para mantener la limpieza del sistema hidráulico.
+   - **Fabricante:** FilterTech.
+   - **Intervalo de Reemplazo:** Cada 6 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.
+
+2. **Juntas Tóricas:**
+   - **Descripción:** Juntas utilizadas para asegurar la estanqueidad de los componentes hidráulicos.
+   - **Fabricante:** SealSystems Ltd.
+   - **Intervalo de Reemplazo:** Cada 12 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.
+
+3. **Tornillos de Seguridad:**
+   - **Descripción:** Tornillos utilizados para asegurar los componentes del tren de aterrizaje.
+   - **Fabricante:** FastenTech.
+   - **Intervalo de Reemplazo:** Cada 24 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.
+
+## Documentación de Inventario
+
+La documentación de inventario es esencial para mantener un registro preciso de los consumibles y expendables utilizados en el tren de aterrizaje. Esta documentación incluye información sobre la cantidad, el estado y la ubicación de los componentes.
+
+### Procedimientos de Documentación
+
+1. **Registro de Entrada:**
+   - Registrar la entrada de nuevos consumibles y expendables en el inventario.
+   - Incluir información sobre la cantidad, el fabricante y la fecha de recepción.
+
+2. **Registro de Salida:**
+   - Registrar la salida de consumibles y expendables del inventario.
+   - Incluir información sobre la cantidad, el uso y la fecha de salida.
+
+3. **Auditorías de Inventario:**
+   - Realizar auditorías periódicas del inventario para asegurar la precisión de los registros.
+   - Comparar los registros de inventario con el stock físico y ajustar cualquier discrepancia.
+
+4. **Mantenimiento de Registros:**
+   - Mantener registros detallados de todos los consumibles y expendables utilizados.
+   - Asegurar que los registros estén actualizados y accesibles para el personal autorizado.
+

--- a/docs/32-20-00_Tren_de_Aterrizaje_de_Nariz.md
+++ b/docs/32-20-00_Tren_de_Aterrizaje_de_Nariz.md
@@ -1,0 +1,79 @@
+# 32-20-00 Tren de Aterrizaje de Nariz
+
+## Descripción del Nose Landing Gear (NLG)
+
+El tren de aterrizaje de nariz (NLG) es un componente esencial del sistema de tren de aterrizaje de la aeronave. Está diseñado para proporcionar dirección durante el rodaje y soportar el peso de la parte delantera de la aeronave durante el despegue, aterrizaje y rodaje. El NLG incluye varios subsistemas y componentes que trabajan en conjunto para proporcionar estabilidad, maniobrabilidad y seguridad.
+
+### Componentes Principales del NLG
+
+1. **Amortiguadores:**
+   - Absorben y disipan la energía del impacto durante el aterrizaje.
+   - Proporcionan una conducción suave durante el rodaje.
+
+2. **Ruedas y Neumáticos:**
+   - Soportan el peso de la parte delantera de la aeronave y proporcionan tracción durante el despegue y aterrizaje.
+   - Diseñados para resistir altas cargas y velocidades.
+
+3. **Sistema de Dirección:**
+   - Permite la dirección de la aeronave durante el rodaje.
+   - Incluye actuadores hidráulicos y sistemas de control.
+
+4. **Estructura del Tren de Aterrizaje:**
+   - Soporta todos los componentes del NLG.
+   - Fabricada con materiales de alta resistencia para soportar cargas extremas.
+
+## Procedimientos de Inspección y Correctivo
+
+### Inspección del NLG
+
+La inspección del tren de aterrizaje de nariz es crucial para garantizar su funcionamiento seguro y eficiente. Las tareas de inspección incluyen verificaciones visuales, pruebas funcionales y mediciones de desgaste.
+
+1. **Inspección Visual:**
+   - Verificación de la integridad estructural de los componentes del NLG.
+   - Inspección de los amortiguadores, ruedas, sistema de dirección y estructura.
+
+2. **Pruebas Funcionales:**
+   - Pruebas de funcionamiento del sistema de dirección.
+   - Verificación del rendimiento de los amortiguadores y ruedas.
+
+3. **Mediciones de Desgaste:**
+   - Medición del desgaste de los neumáticos.
+   - Verificación del desgaste de los componentes del sistema de dirección.
+
+### Procedimientos Correctivos
+
+Los procedimientos correctivos son necesarios para abordar cualquier problema identificado durante las inspecciones. Estos procedimientos incluyen reparaciones, reemplazos y ajustes de componentes.
+
+1. **Reparaciones:**
+   - Reparación de componentes dañados o desgastados.
+   - Aplicación de parches y refuerzos según sea necesario.
+
+2. **Reemplazos:**
+   - Sustitución de neumáticos desgastados.
+   - Reemplazo de amortiguadores y componentes del sistema de dirección según sea necesario.
+
+3. **Ajustes:**
+   - Ajuste de la alineación del sistema de dirección.
+   - Calibración de los actuadores hidráulicos para asegurar un funcionamiento preciso.
+
+### Partes y Referencias
+
+1. **Amortiguadores:**
+   - P/N: AMORT-NLG-001
+   - Fabricante: LandingGear Innovations
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/amortiguadores)
+
+2. **Ruedas y Neumáticos:**
+   - P/N: RUEDA-NLG-002
+   - Fabricante: AeroTires Inc.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/ruedas)
+
+3. **Sistema de Dirección:**
+   - P/N: DIR-NLG-003
+   - Fabricante: SteerTech Systems
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/direccion)
+
+4. **Estructura del Tren de Aterrizaje:**
+   - P/N: ESTRUCT-NLG-004
+   - Fabricante: StrongStructures Ltd.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/estructura)

--- a/docs/32-30-00_Sistemas_de_Control_del_Tren_de_Aterrizaje.md
+++ b/docs/32-30-00_Sistemas_de_Control_del_Tren_de_Aterrizaje.md
@@ -1,0 +1,94 @@
+# 32-30-00 Sistemas de Control del Tren de Aterrizaje
+
+## Mecanismos y Sensores de Control
+
+El sistema de control del tren de aterrizaje incluye una serie de mecanismos y sensores que aseguran la correcta operación del tren de aterrizaje durante las fases de despegue, aterrizaje y rodaje. Estos componentes son esenciales para la seguridad y eficiencia de la aeronave.
+
+### Mecanismos de Control
+
+1. **Actuadores Hidráulicos:**
+   - Proporcionan la fuerza necesaria para extender y retraer el tren de aterrizaje.
+   - Operan bajo alta presión hidráulica y están diseñados para soportar cargas significativas.
+
+2. **Válvulas de Control:**
+   - Regulan el flujo de fluido hidráulico hacia los actuadores.
+   - Aseguran una operación suave y controlada del tren de aterrizaje.
+
+3. **Bomba Hidráulica:**
+   - Genera la presión hidráulica necesaria para operar los actuadores y válvulas.
+   - Puede ser accionada por el motor de la aeronave o por un sistema eléctrico independiente.
+
+### Sensores de Control
+
+1. **Sensores de Posición:**
+   - Detectan la posición del tren de aterrizaje (extendido o retraído).
+   - Proporcionan información crítica al sistema de control de la aeronave.
+
+2. **Sensores de Presión:**
+   - Monitorean la presión hidráulica en el sistema de control del tren de aterrizaje.
+   - Aseguran que la presión se mantenga dentro de los límites operativos seguros.
+
+3. **Sensores de Velocidad:**
+   - Miden la velocidad de extensión y retracción del tren de aterrizaje.
+   - Ayudan a prevenir operaciones demasiado rápidas o lentas que podrían dañar el sistema.
+
+## Interfaz con Cockpit y Circuitos Electrónicos
+
+El sistema de control del tren de aterrizaje está estrechamente integrado con el cockpit y los circuitos electrónicos de la aeronave. Esta integración permite a los pilotos monitorear y controlar el tren de aterrizaje de manera efectiva.
+
+### Indicadores en el Cockpit
+
+1. **Luces de Estado del Tren de Aterrizaje:**
+   - Indican si el tren de aterrizaje está extendido, retraído o en tránsito.
+   - Proporcionan una indicación visual clara y rápida para los pilotos.
+
+2. **Alarmas de Fallo:**
+   - Alertan a los pilotos sobre cualquier fallo en el sistema de control del tren de aterrizaje.
+   - Incluyen alarmas sonoras y visuales para asegurar una respuesta rápida.
+
+### Circuitos Electrónicos
+
+1. **Unidad de Control Electrónico (ECU):**
+   - Procesa las señales de los sensores y controla los actuadores y válvulas.
+   - Asegura una operación coordinada y segura del tren de aterrizaje.
+
+2. **Red de Comunicación:**
+   - Conecta la ECU con otros sistemas de la aeronave, como el sistema de gestión de vuelo (FMS).
+   - Permite la transmisión de datos en tiempo real para un control y monitoreo efectivos.
+
+3. **Sistema de Diagnóstico:**
+   - Monitorea continuamente el estado del sistema de control del tren de aterrizaje.
+   - Proporciona diagnósticos y recomendaciones de mantenimiento en caso de fallos.
+
+## Mantenimiento y Pruebas Funcionales
+
+El mantenimiento regular y las pruebas funcionales son esenciales para asegurar la fiabilidad y seguridad del sistema de control del tren de aterrizaje.
+
+### Procedimientos de Mantenimiento
+
+1. **Inspección Visual:**
+   - Revisar visualmente todos los componentes del sistema de control del tren de aterrizaje.
+   - Buscar signos de desgaste, daños o fugas hidráulicas.
+
+2. **Pruebas de Operación:**
+   - Realizar pruebas de extensión y retracción del tren de aterrizaje.
+   - Verificar el funcionamiento correcto de los actuadores, válvulas y sensores.
+
+3. **Mantenimiento Preventivo:**
+   - Reemplazar componentes críticos según el programa de mantenimiento preventivo.
+   - Asegurar que todos los sistemas estén en condiciones óptimas de operación.
+
+### Pruebas Funcionales
+
+1. **Pruebas de Presión Hidráulica:**
+   - Verificar que la presión hidráulica esté dentro de los límites operativos.
+   - Asegurar que no haya fugas ni caídas de presión.
+
+2. **Pruebas de Sensores:**
+   - Calibrar y verificar el funcionamiento de todos los sensores de posición, presión y velocidad.
+   - Asegurar que los datos proporcionados sean precisos y fiables.
+
+3. **Pruebas de Integración:**
+   - Verificar la integración del sistema de control del tren de aterrizaje con el cockpit y otros sistemas de la aeronave.
+   - Asegurar que todas las señales y comandos se transmitan y procesen correctamente.
+

--- a/docs/32-40-00_Sistema_de_Frenado_del_Tren_de_Aterrizaje.md
+++ b/docs/32-40-00_Sistema_de_Frenado_del_Tren_de_Aterrizaje.md
@@ -1,0 +1,79 @@
+# 32-40-00 Sistema de Frenado del Tren de Aterrizaje
+
+## Descripción del Sistema de Frenado
+
+El sistema de frenado del tren de aterrizaje es un componente crucial para la seguridad y el rendimiento de la aeronave. Está diseñado para proporcionar la capacidad de detener la aeronave de manera segura durante el aterrizaje y el rodaje. Este sistema incluye varios subsistemas y componentes que trabajan en conjunto para proporcionar una frenada eficiente y controlada.
+
+### Componentes Principales del Sistema de Frenado
+
+1. **Frenos:**
+   - Proporcionan la capacidad de detener la aeronave de manera segura.
+   - Incluyen discos de freno, pastillas de freno y pinzas de freno.
+
+2. **Discos de Freno:**
+   - Componentes clave que generan fricción para detener la aeronave.
+   - Fabricados con materiales de alta resistencia al calor y al desgaste.
+
+3. **Actuadores Hidráulicos:**
+   - Proporcionan la fuerza necesaria para aplicar los frenos.
+   - Operan bajo alta presión hidráulica y están diseñados para soportar cargas significativas.
+
+4. **Sistema de Monitoreo de Desgaste:**
+   - Monitorea el desgaste de los componentes del sistema de frenado.
+   - Proporciona alertas y recomendaciones de mantenimiento.
+
+## Programas de Mantenimiento y Pruebas Funcionales
+
+### Mantenimiento del Sistema de Frenado
+
+El mantenimiento del sistema de frenado es esencial para garantizar su funcionamiento seguro y eficiente. Las tareas de mantenimiento incluyen inspecciones regulares, reemplazo de componentes desgastados y ajustes necesarios.
+
+1. **Inspecciones Regulares:**
+   - Inspección visual de los componentes del sistema de frenado.
+   - Verificación de la integridad estructural y funcionalidad de los frenos, discos de freno y actuadores hidráulicos.
+
+2. **Reemplazo de Componentes:**
+   - Sustitución de pastillas de freno desgastadas.
+   - Reemplazo de discos de freno y actuadores hidráulicos según sea necesario.
+
+3. **Ajustes y Calibraciones:**
+   - Ajuste de la presión de los actuadores hidráulicos.
+   - Calibración del sistema de monitoreo de desgaste para asegurar un funcionamiento preciso.
+
+### Pruebas Funcionales
+
+Las pruebas funcionales son necesarias para verificar el correcto funcionamiento del sistema de frenado. Estas pruebas incluyen verificaciones de presión hidráulica, pruebas de fricción y pruebas de integración.
+
+1. **Pruebas de Presión Hidráulica:**
+   - Verificar que la presión hidráulica esté dentro de los límites operativos.
+   - Asegurar que no haya fugas ni caídas de presión.
+
+2. **Pruebas de Fricción:**
+   - Medir la fricción generada por los discos de freno.
+   - Asegurar que los frenos proporcionen la capacidad de frenado necesaria.
+
+3. **Pruebas de Integración:**
+   - Verificar la integración del sistema de frenado con otros sistemas de la aeronave.
+   - Asegurar que todas las señales y comandos se transmitan y procesen correctamente.
+
+### Partes y Referencias
+
+1. **Frenos:**
+   - P/N: FRENO-MLG-001
+   - Fabricante: BrakeTech Systems
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/frenos)
+
+2. **Discos de Freno:**
+   - P/N: DISCO-MLG-002
+   - Fabricante: BrakeDiscs Inc.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/discos)
+
+3. **Actuadores Hidráulicos:**
+   - P/N: ACT-HYD-MLG-003
+   - Fabricante: HydroActuators Ltd.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/actuadores)
+
+4. **Sistema de Monitoreo de Desgaste:**
+   - P/N: MON-DESG-MLG-004
+   - Fabricante: WearMonitor Systems
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/monitoreo)

--- a/docs/32-50-00_Sistema_de_Retraccion_del_Tren_de_Aterrizaje.md
+++ b/docs/32-50-00_Sistema_de_Retraccion_del_Tren_de_Aterrizaje.md
@@ -1,0 +1,98 @@
+# 32-50-00 Sistema de Retracción del Tren de Aterrizaje
+
+## Descripción del Sistema de Retracción
+
+El sistema de retracción del tren de aterrizaje es un componente crucial para la operación segura y eficiente de la aeronave. Este sistema permite retraer y extender el tren de aterrizaje durante las fases de despegue y aterrizaje, mejorando la aerodinámica y reduciendo la resistencia al avance.
+
+### Componentes Principales del Sistema de Retracción
+
+1. **Bomba Hidráulica:**
+   - Genera la presión hidráulica necesaria para operar los actuadores de retracción.
+   - Puede ser accionada por el motor de la aeronave o por un sistema eléctrico independiente.
+
+2. **Actuadores de Retracción:**
+   - Proporcionan la fuerza necesaria para retraer y extender el tren de aterrizaje.
+   - Operan bajo alta presión hidráulica y están diseñados para soportar cargas significativas.
+
+3. **Válvulas de Control:**
+   - Regulan el flujo de fluido hidráulico hacia los actuadores de retracción.
+   - Aseguran una operación suave y controlada del tren de aterrizaje.
+
+4. **Sensores de Posición:**
+   - Detectan la posición del tren de aterrizaje (extendido o retraído).
+   - Proporcionan información crítica al sistema de control de la aeronave.
+
+5. **Sistema de Monitoreo:**
+   - Monitorea continuamente el estado del sistema de retracción.
+   - Proporciona diagnósticos y alertas en caso de fallos.
+
+## Secuencia de Retracción
+
+La secuencia de retracción del tren de aterrizaje es un proceso cuidadosamente coordinado que asegura una operación segura y eficiente. A continuación se describe la secuencia típica de retracción:
+
+1. **Inicio de la Retracción:**
+   - El piloto activa el comando de retracción desde el cockpit.
+   - La bomba hidráulica se enciende y comienza a generar presión.
+
+2. **Extensión de los Actuadores:**
+   - Los actuadores de retracción se extienden, aplicando fuerza al tren de aterrizaje.
+   - Las válvulas de control regulan el flujo de fluido hidráulico para asegurar una operación suave.
+
+3. **Retracción del Tren de Aterrizaje:**
+   - El tren de aterrizaje comienza a retraerse hacia el fuselaje de la aeronave.
+   - Los sensores de posición monitorean el movimiento y proporcionan información en tiempo real.
+
+4. **Cierre de las Puertas del Tren de Aterrizaje:**
+   - Una vez que el tren de aterrizaje está completamente retraído, las puertas del tren de aterrizaje se cierran.
+   - Los actuadores de las puertas aseguran un cierre hermético para mejorar la aerodinámica.
+
+5. **Finalización de la Retracción:**
+   - El sistema de monitoreo verifica que el tren de aterrizaje esté completamente retraído y las puertas cerradas.
+   - Se proporciona una indicación visual y sonora en el cockpit para confirmar la finalización exitosa de la retracción.
+
+## Procedimientos de Ajuste y Calibración
+
+El ajuste y la calibración del sistema de retracción del tren de aterrizaje son esenciales para asegurar su funcionamiento correcto y la seguridad de la aeronave. A continuación se describen los procedimientos típicos de ajuste y calibración:
+
+1. **Ajuste de la Presión Hidráulica:**
+   - Verificar y ajustar la presión hidráulica generada por la bomba.
+   - Asegurar que la presión esté dentro de los límites operativos especificados.
+
+2. **Calibración de los Sensores de Posición:**
+   - Verificar y calibrar los sensores de posición para asegurar lecturas precisas.
+   - Asegurar que los sensores proporcionen información confiable al sistema de control.
+
+3. **Ajuste de los Actuadores de Retracción:**
+   - Verificar y ajustar la extensión y retracción de los actuadores.
+   - Asegurar que los actuadores operen suavemente y sin obstrucciones.
+
+4. **Pruebas Funcionales:**
+   - Realizar pruebas de retracción y extensión del tren de aterrizaje.
+   - Verificar el funcionamiento correcto de todos los componentes del sistema.
+
+### Partes y Referencias
+
+1. **Bomba Hidráulica:**
+   - P/N: BOMBA-RET-001
+   - Fabricante: HydroPump Systems
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/bomba)
+
+2. **Actuadores de Retracción:**
+   - P/N: ACT-RET-002
+   - Fabricante: ActuatorTech Inc.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/actuadores)
+
+3. **Válvulas de Control:**
+   - P/N: VALV-RET-003
+   - Fabricante: ValveControl Ltd.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/valvulas)
+
+4. **Sensores de Posición:**
+   - P/N: SENSOR-RET-004
+   - Fabricante: SensorTech Systems
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/sensores)
+
+5. **Sistema de Monitoreo:**
+   - P/N: MON-RET-005
+   - Fabricante: MonitorSystems Inc.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/monitoreo)

--- a/docs/32-60-00_Puertas_del_Tren_de_Aterrizaje.md
+++ b/docs/32-60-00_Puertas_del_Tren_de_Aterrizaje.md
@@ -1,0 +1,62 @@
+# 32-60-00 Puertas del Tren de Aterrizaje
+
+## Descripción de las Puertas del Tren de Aterrizaje
+
+Las puertas del tren de aterrizaje son componentes críticos que protegen el tren de aterrizaje cuando está retraído y mejoran la aerodinámica de la aeronave. Incluyen varios subsistemas y componentes que aseguran su funcionamiento correcto.
+
+### Tipos de Puertas
+
+1. **Puertas Principales:**
+   - Cubren el tren de aterrizaje principal cuando está retraído.
+   - Fabricadas con materiales compuestos ligeros y resistentes.
+
+2. **Puertas de Nariz:**
+   - Cubren el tren de aterrizaje de nariz cuando está retraído.
+   - Diseñadas para soportar las condiciones ambientales y operativas.
+
+### Componentes Principales de las Puertas del Tren de Aterrizaje
+
+1. **Bisagras:**
+   - Permiten la apertura y cierre de las puertas.
+   - Fabricadas con materiales de alta resistencia para soportar cargas significativas.
+
+2. **Actuadores:**
+   - Proporcionan la fuerza necesaria para abrir y cerrar las puertas.
+   - Operan bajo alta presión hidráulica y están diseñados para un funcionamiento preciso.
+
+3. **Sistemas de Cierre y Sellado:**
+   - Aseguran que las puertas permanezcan cerradas durante el vuelo.
+   - Proporcionan un sellado hermético para mejorar la aerodinámica.
+
+## Ajustes, Tolerancias y Alineación
+
+El ajuste, las tolerancias y la alineación de las puertas del tren de aterrizaje son esenciales para asegurar su funcionamiento correcto y la seguridad de la aeronave. A continuación se describen los procedimientos típicos de ajuste, tolerancias y alineación:
+
+1. **Ajuste de las Bisagras:**
+   - Verificar y ajustar la alineación de las bisagras para asegurar un funcionamiento suave.
+   - Asegurar que las bisagras estén lubricadas adecuadamente para reducir el desgaste.
+
+2. **Tolerancias de las Puertas:**
+   - Verificar que las puertas cumplan con las tolerancias especificadas para asegurar un sellado hermético.
+   - Asegurar que las puertas no presenten deformaciones o daños que puedan afectar su funcionamiento.
+
+3. **Alineación de los Actuadores:**
+   - Verificar y ajustar la alineación de los actuadores para asegurar un funcionamiento preciso.
+   - Asegurar que los actuadores operen suavemente y sin obstrucciones.
+
+### Partes y Referencias
+
+1. **Bisagras:**
+   - P/N: BISAGRA-PTA-001
+   - Fabricante: HingeTech Solutions
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/bisagras)
+
+2. **Actuadores:**
+   - P/N: ACT-PTA-002
+   - Fabricante: ActuatorTech Inc.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/actuadores)
+
+3. **Sistemas de Cierre y Sellado:**
+   - P/N: SELLO-PTA-003
+   - Fabricante: SealSystems Ltd.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/sellos)

--- a/docs/32-70-00_Indicadores_y_Sistemas_de_Alerta_del_Tren_de_Aterrizaje.md
+++ b/docs/32-70-00_Indicadores_y_Sistemas_de_Alerta_del_Tren_de_Aterrizaje.md
@@ -1,0 +1,68 @@
+# 32-70-00 Indicadores y Sistemas de Alerta del Tren de Aterrizaje
+
+## Descripción de los Indicadores y Sistemas de Alerta
+
+Los indicadores y sistemas de alerta del tren de aterrizaje son componentes críticos para la seguridad de la aeronave. Estos sistemas proporcionan información visual y auditiva a los pilotos sobre el estado del tren de aterrizaje, asegurando que esté correctamente extendido o retraído durante las fases de despegue, aterrizaje y rodaje.
+
+### Componentes Principales
+
+1. **Luces de Tren de Aterrizaje:**
+   - Proporcionan una indicación visual del estado del tren de aterrizaje.
+   - Incluyen luces verdes (tren extendido y bloqueado), luces rojas (tren en tránsito) y luces apagadas (tren retraído).
+
+2. **Alarmas de Tren de Aterrizaje:**
+   - Proporcionan una alerta auditiva en caso de fallo o estado anómalo del tren de aterrizaje.
+   - Incluyen alarmas sonoras que se activan si el tren de aterrizaje no está en la posición correcta durante el despegue o aterrizaje.
+
+3. **Señales de Posición:**
+   - Detectan y transmiten la posición del tren de aterrizaje (extendido o retraído).
+   - Incluyen sensores de posición y sistemas de transmisión de datos al cockpit.
+
+## Diagnóstico y Resolución de Fallos en Alertas
+
+El diagnóstico y la resolución de fallos en los sistemas de alerta del tren de aterrizaje son esenciales para mantener la seguridad de la aeronave. Los procedimientos incluyen la identificación de fallos, la realización de pruebas y la implementación de soluciones correctivas.
+
+### Procedimientos de Diagnóstico
+
+1. **Inspección Visual:**
+   - Verificación visual de los componentes del sistema de alerta.
+   - Inspección de las luces, alarmas y sensores de posición.
+
+2. **Pruebas Funcionales:**
+   - Realización de pruebas para verificar el funcionamiento correcto de las luces y alarmas.
+   - Pruebas de los sensores de posición para asegurar que transmiten datos precisos.
+
+3. **Lectura de Códigos de Error:**
+   - Uso de equipos de diagnóstico para leer y analizar los códigos de error generados por el sistema de alerta.
+   - Identificación de fallos específicos basados en los códigos de error.
+
+### Resolución de Fallos
+
+1. **Reemplazo de Componentes:**
+   - Sustitución de luces, alarmas o sensores de posición defectuosos.
+   - Uso de componentes de repuesto aprobados y compatibles.
+
+2. **Ajustes y Calibraciones:**
+   - Ajuste de la alineación de los sensores de posición.
+   - Calibración de las alarmas para asegurar que se activen en los momentos correctos.
+
+3. **Actualización de Software:**
+   - Instalación de actualizaciones de software para mejorar la funcionalidad y fiabilidad del sistema de alerta.
+   - Verificación de la compatibilidad de las actualizaciones con el sistema existente.
+
+### Partes y Referencias
+
+1. **Luces de Tren de Aterrizaje:**
+   - P/N: LUZ-TRN-001
+   - Fabricante: LightTech Systems
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/luces)
+
+2. **Alarmas de Tren de Aterrizaje:**
+   - P/N: ALM-TRN-002
+   - Fabricante: AlertSystems Inc.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/alarmas)
+
+3. **Sensores de Posición:**
+   - P/N: SNS-TRN-003
+   - Fabricante: SensorTech Solutions
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/sensores)

--- a/docs/32-80-00_Sistemas_Hidraulicos_para_el_Tren_de_Aterrizaje.md
+++ b/docs/32-80-00_Sistemas_Hidraulicos_para_el_Tren_de_Aterrizaje.md
@@ -1,0 +1,75 @@
+# 32-80-00 Sistemas Hidráulicos para el Tren de Aterrizaje
+
+## Descripción de los Sistemas Hidráulicos
+
+Los sistemas hidráulicos dedicados al tren de aterrizaje son esenciales para la operación segura y eficiente de la aeronave. Estos sistemas proporcionan la fuerza necesaria para extender y retraer el tren de aterrizaje, así como para operar los frenos y otros componentes críticos. Los sistemas hidráulicos incluyen varios subsistemas y componentes que trabajan en conjunto para proporcionar un rendimiento fiable y controlado.
+
+### Componentes Principales de los Sistemas Hidráulicos
+
+1. **Líneas Hidráulicas:**
+   - Transportan el fluido hidráulico desde la bomba hasta los actuadores y válvulas.
+   - Fabricadas con materiales de alta resistencia para soportar altas presiones y temperaturas.
+
+2. **Válvulas Hidráulicas:**
+   - Regulan el flujo de fluido hidráulico hacia los actuadores.
+   - Aseguran una operación suave y controlada del tren de aterrizaje.
+
+3. **Bomba Hidráulica:**
+   - Genera la presión hidráulica necesaria para operar los actuadores y válvulas.
+   - Puede ser accionada por el motor de la aeronave o por un sistema eléctrico independiente.
+
+4. **Depósitos de Fluido Hidráulico:**
+   - Almacenan el fluido hidráulico necesario para el funcionamiento del sistema.
+   - Incluyen filtros y sistemas de monitoreo de nivel de fluido.
+
+## Procedimientos de Mantenimiento de los Sistemas Hidráulicos
+
+### Mantenimiento Regular
+
+El mantenimiento regular de los sistemas hidráulicos es crucial para garantizar su funcionamiento seguro y eficiente. Las tareas de mantenimiento incluyen inspecciones regulares, reemplazo de componentes desgastados y ajustes necesarios.
+
+1. **Inspecciones Regulares:**
+   - Inspección visual de las líneas hidráulicas, válvulas, bomba y depósitos.
+   - Verificación de la integridad estructural y funcionalidad de los componentes.
+
+2. **Reemplazo de Componentes:**
+   - Sustitución de líneas hidráulicas desgastadas o dañadas.
+   - Reemplazo de válvulas y componentes de la bomba según sea necesario.
+
+3. **Ajustes y Calibraciones:**
+   - Ajuste de la presión de la bomba hidráulica.
+   - Calibración de las válvulas hidráulicas para asegurar un funcionamiento preciso.
+
+### Procedimientos de Purga y Mantenimiento de Fluidos
+
+La purga y el mantenimiento de los fluidos hidráulicos son esenciales para asegurar la eficiencia y fiabilidad del sistema. Estos procedimientos incluyen la eliminación de aire y contaminantes del sistema, así como la reposición de fluido hidráulico.
+
+1. **Procedimientos de Purga:**
+   - Eliminar el aire atrapado en las líneas hidráulicas.
+   - Asegurar que el sistema esté completamente lleno de fluido hidráulico sin burbujas de aire.
+
+2. **Mantenimiento de Fluidos:**
+   - Verificar y mantener el nivel adecuado de fluido hidráulico en los depósitos.
+   - Reemplazar el fluido hidráulico según el programa de mantenimiento preventivo.
+
+### Partes y Referencias
+
+1. **Líneas Hidráulicas:**
+   - P/N: LINEA-HYD-001
+   - Fabricante: HydroLines Inc.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/lineas)
+
+2. **Válvulas Hidráulicas:**
+   - P/N: VALV-HYD-002
+   - Fabricante: ValveTech Systems
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/valvulas)
+
+3. **Bomba Hidráulica:**
+   - P/N: BOMBA-HYD-003
+   - Fabricante: PumpTech Ltd.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/bomba)
+
+4. **Depósitos de Fluido Hidráulico:**
+   - P/N: DEPOS-HYD-004
+   - Fabricante: FluidReservoirs Co.
+   - Manual de Mantenimiento: [Enlace al Manual](https://example.com/manuales/depositos)

--- a/docs/32-90-00_Sistemas_de_Lubricacion_del_Tren_de_Aterrizaje.md
+++ b/docs/32-90-00_Sistemas_de_Lubricacion_del_Tren_de_Aterrizaje.md
@@ -1,0 +1,80 @@
+# 32-90-00 Sistemas de Lubricación del Tren de Aterrizaje
+
+## Descripción de los Sistemas de Lubricación
+
+Los sistemas de lubricación del tren de aterrizaje son esenciales para garantizar el funcionamiento suave y eficiente de los componentes móviles. Estos sistemas reducen la fricción, el desgaste y el calentamiento, prolongando la vida útil de los componentes y mejorando la seguridad y el rendimiento de la aeronave.
+
+### Puntos de Lubricación
+
+1. **Amortiguadores:**
+   - Puntos de lubricación en las juntas y superficies de contacto.
+   - Lubricación regular para asegurar un funcionamiento suave y reducir el desgaste.
+
+2. **Ruedas y Ejes:**
+   - Puntos de lubricación en los rodamientos y ejes de las ruedas.
+   - Lubricación adecuada para reducir la fricción y el calentamiento durante el rodaje.
+
+3. **Bisagras y Actuadores:**
+   - Puntos de lubricación en las bisagras de las puertas del tren de aterrizaje y en los actuadores hidráulicos.
+   - Lubricación para asegurar un movimiento suave y preciso.
+
+### Tipos de Lubricantes
+
+1. **Grasas:**
+   - Grasas de alta temperatura y alta presión para los amortiguadores y rodamientos.
+   - Proporcionan una lubricación duradera y resistente a condiciones extremas.
+
+2. **Aceites:**
+   - Aceites de baja viscosidad para los ejes y superficies de contacto.
+   - Aseguran una lubricación rápida y eficiente en condiciones de alta velocidad.
+
+3. **Lubricantes Sólidos:**
+   - Lubricantes sólidos como el grafito o el disulfuro de molibdeno para aplicaciones específicas.
+   - Proporcionan una lubricación duradera en condiciones de alta carga y baja velocidad.
+
+### Intervalos de Lubricación
+
+1. **Lubricación Diaria:**
+   - Inspección y lubricación de los puntos críticos antes de cada vuelo.
+   - Asegurar que todos los componentes estén adecuadamente lubricados para el vuelo.
+
+2. **Lubricación Semanal:**
+   - Lubricación de todos los puntos de contacto y superficies móviles.
+   - Verificación de la condición de los lubricantes y reemplazo si es necesario.
+
+3. **Lubricación Mensual:**
+   - Inspección y lubricación completa de todos los sistemas de lubricación del tren de aterrizaje.
+   - Reemplazo de lubricantes y limpieza de los puntos de lubricación.
+
+## Prácticas Estándar para Reducir Desgaste
+
+### Inspección Regular
+
+1. **Inspección Visual:**
+   - Verificación visual de los puntos de lubricación y componentes móviles.
+   - Identificación de signos de desgaste, fricción excesiva o falta de lubricación.
+
+2. **Pruebas Funcionales:**
+   - Pruebas de funcionamiento de los componentes móviles para asegurar un movimiento suave y sin fricción.
+   - Verificación del rendimiento de los sistemas de lubricación.
+
+### Mantenimiento Preventivo
+
+1. **Reemplazo de Lubricantes:**
+   - Reemplazo regular de los lubricantes según el programa de mantenimiento preventivo.
+   - Asegurar que los lubricantes estén en condiciones óptimas para proporcionar una lubricación efectiva.
+
+2. **Limpieza de Puntos de Lubricación:**
+   - Limpieza regular de los puntos de lubricación para eliminar contaminantes y residuos.
+   - Asegurar que los puntos de lubricación estén limpios y libres de obstrucciones.
+
+### Capacitación del Personal
+
+1. **Entrenamiento en Lubricación:**
+   - Capacitación del personal de mantenimiento en las técnicas y procedimientos de lubricación.
+   - Asegurar que el personal esté familiarizado con los tipos de lubricantes y los intervalos de lubricación.
+
+2. **Documentación y Registros:**
+   - Mantener registros detallados de las actividades de lubricación y mantenimiento.
+   - Documentar los intervalos de lubricación, los tipos de lubricantes utilizados y cualquier problema identificado.
+

--- a/docs/ATA.md
+++ b/docs/ATA.md
@@ -1,0 +1,123 @@
+# ATA Chapter-Based Documentation Index
+
+## Tabla de Contenidos
+
+1. [**Introducción**](./Introduccion.md)  
+   - Alcance general del documento  
+   - Convenciones de uso y referencias normativas (ej. S1000D, ATA iSpec 2200, etc.)  
+   - Definiciones, abreviaturas, siglas
+
+2. [**Estructura de Numeración ATA**](./Estructura_de_Numeracion_ATA.md)  
+   - Descripción de la metodología ATA (Capítulo, Sección, Sub-Sección)  
+   - Convenciones para numerar secciones específicas de Tren de Aterrizaje
+
+3. [**Índice Completo**](./Indice_Completo.md)  
+   - **Capítulo 32 - Tren de Aterrizaje**  
+     - [**32-00-00** Tren de Aterrizaje (General)](./32-00-00_Tren_de_Aterrizaje.md)  
+       - Descripción global del sistema de Tren de Aterrizaje  
+       - Identificación de componentes principales
+     - [**32-10-00** Tren de Aterrizaje Principal y Puertas](./32-10-00_Tren_de_Aterrizaje_Principal_y_Puertas.md)  
+       - Descripción detallada del tren principal (MLG)  
+       - Mantenimiento, inspección, partes y referencias
+     - [**32-20-00** Tren de Aterrizaje de Nariz](./32-20-00_Tren_de_Aterrizaje_de_Nariz.md)  
+       - Descripción del Nose Landing Gear (NLG)  
+       - Procedimientos de inspección y correctivo
+     - [**32-30-00** Sistemas de Control del Tren de Aterrizaje](./32-30-00_Sistemas_de_Control_del_Tren_de_Aterrizaje.md)  
+       - Mecanismos y sensores de control  
+       - Interfaz con cockpit y circuitos electrónicos
+     - [**32-40-00** Sistema de Frenado del Tren de Aterrizaje](./32-40-00_Sistema_de_Frenado_del_Tren_de_Aterrizaje.md)  
+       - Frenos, discos, actuadores hidráulicos, monitoreo de desgaste  
+       - Programas de mantenimiento y pruebas funcionales
+     - [**32-50-00** Sistema de Retracción del Tren de Aterrizaje](./32-50-00_Sistema_de_Retraccion_del_Tren_de_Aterrizaje.md)  
+       - Bomba hidráulica, brazos de retracción, secuencia de retracción  
+       - Procedimientos de ajuste y calibración
+     - [**32-60-00** Puertas del Tren de Aterrizaje](./32-60-00_Puertas_del_Tren_de_Aterrizaje.md)  
+       - Tipos de puertas (principal, nariz), bisagras, actuadores  
+       - Ajustes, tolerancias, alineación
+     - [**32-70-00** Indicadores y Sistemas de Alerta del Tren de Aterrizaje](./32-70-00_Indicadores_y_Sistemas_de_Alerta_del_Tren_de_Aterrizaje.md)  
+       - LUCES de tren, alarmas, señales de posición  
+       - Diagnóstico y resolución de fallos en alertas
+     - [**32-80-00** Sistemas Hidráulicos para el Tren de Aterrizaje](./32-80-00_Sistemas_Hidraulicos_para_el_Tren_de_Aterrizaje.md)  
+       - Líneas y válvulas hidráulicas dedicadas al tren  
+       - Depósitos, purga y mantenimiento de fluidos
+     - [**32-90-00** Sistemas de Lubricación del Tren de Aterrizaje](./32-90-00_Sistemas_de_Lubricacion_del_Tren_de_Aterrizaje.md)  
+       - Puntos de lubricación, tipos de lubricantes, intervalos  
+       - Prácticas estándar para reducir desgaste
+     - [**32-100-00** Sistemas de Respaldo y Emergencia del Tren de Aterrizaje](./32-100-00_Sistemas_de_Respaldo_y_Emergencia_del_Tren_de_Aterrizaje.md)  
+       - Mecanismos de liberación emergente  
+       - Procedimientos en caso de fallo hidráulico
+     - [**32-110-00** FIN, Consumibles y Expendables](./32-110-00_FIN_Consumibles_y_Expendables.md)  
+       - Functional Item Numbers (FIN), partes de uso único o consumibles  
+       - Identificación de repuestos, documentación de inventario
+
+4. [**Gestión de CSN (Catalogue Serial Numbers)**](./Gestion_de_CSN.md)  
+   - Estructura de numeración para ítems seriados  
+   - Rastreo de componentes y subcomponentes en el ciclo de vida
+
+5. [**Gestión de FIN (Functional Instrument Numbers)**](./Gestion_de_FIN.md)  
+   - Asignación de FIN a cada subsistema  
+   - Interacción con la CSDB y el DMRL
+
+6. [**Consumibles y Expendables**](./Consumibles_y_Expendables.md)  
+   - Lista detallada de consumibles (aceites, grasas, sellantes)  
+   - Procedencias, intervalos de uso, métodos de descarte
+
+7. [**Procedimientos de Mantenimiento**](./Procedimientos_de_Mantenimiento.md)  
+   - Mantenimientos rutinarios, preventivos y correctivos  
+   - Checklists y secuencias de inspección  
+   - Referencias cruzadas a Data Modules S1000D (Módulos de mantenimiento, BOI, etc.)
+
+8. [**Seguridad y Precauciones**](./Seguridad_y_Precauciones.md)  
+   - Reglas generales de seguridad en línea de vuelo y hangar  
+   - Precauciones específicas para la manipulación del tren de aterrizaje  
+   - EPP (Equipos de Protección Personal) requeridos
+
+9. [**Anexos**](./Anexos.md)  
+   - Planos, diagramas de flujo, tablas de torque o apriete  
+   - Guías de interpretación de alarmas específicas  
+   - Documentación complementaria (Instrucciones de Servicio, Boletines, etc.)
+
+## Comentarios Generales
+
+- **01. Nomenclatura:**  
+  Cada archivo Markdown está **alineado con la numeración ATA** y descrito en su nombre.  
+  Por ejemplo, 32-30-00_Sistemas_de_Control_del_Tren_de_Aterrizaje.md.
+
+- **02. S1000D Referencias (Opcional):**  
+  Si estás trabajando con S1000D, cada sección puede vincularse a Data Modules (p. ej., 32-30-00-00-00A-000A-D.xml para Description, 32-30-00-00-00A-000A-M.xml para Maintenance).  
+  Desde estos Markdown, podrías referenciar DMRL entries, BOM, IPC, etc.
+
+- **03. Versionado y Control de Cambios:**  
+  Dado que cada archivo es un documento Markdown, usar un repositorio Git (u otro VCS) para mantener historial de ediciones, revisiones y aprobaciones.  
+  Incluir al inicio de cada Markdown una cabecera con la versión, fecha y responsable.
+
+- **04. Integración con CSDB (si corresponde):**  
+  Estos archivos pueden ser complementarios a una base de datos S1000D, sirviendo como índice o “front-end” narrativo. Los detalles técnicos (p.ej., pasos de mantenimiento, listados de piezas) residirían en Data Modules XML que se referencian desde aquí.
+
+- **05. Expandir/Desglosar Subniveles:**  
+  Si tu proyecto necesita mayor granularidad (p.ej., 32-10-10, 32-10-20, etc.), simplemente anida más niveles de directorios y archivos. La idea es mantener la coherencia con la estructura ATA sin complicar en exceso la navegación.
+
+- **06. FIN y CSN:**  
+  Los puntos 4 y 5 (Gestión de CSN, Gestión de FIN) aluden a cómo se identifican componentes e instrumentos. Podrías añadir ejemplos reales (p.ej., FIN 32-30-XX-XX) y un pequeño glosario para personal nuevo en el proyecto.
+
+- **07. Procedimientos y Seguridad:**  
+  Se incluye una sección independiente (cap. 7 y 8) para unificar y destacar la importancia de los procedimientos, además de la seguridad operativa. Mantener estos apartados cohesivos facilita al usuario encontrar guías generales de forma rápida.
+
+- **08. Anexos y Documentación Extra:**  
+  Anexos (cap. 9) puede albergar tablas detalladas, manuales de torque, fichas de datos de materiales, etc. Incluso documentos complementarios (p.ej., TSM - Troubleshooting Manual, OIT - Operator Information Telex, etc.).
+
+## Posibles Mejoras
+
+1. **Auto-Generar el Índice:**  
+   Usar un script (Python, Node.js, etc.) que lea la carpeta “ATA32” y cree dinámicamente la tabla de contenido en Markdown, de modo que los enlaces se actualicen automáticamente al agregar o renombrar archivos.
+
+2. **BREX (Business Rules Exchange) y Applicability:**  
+   Si trabajas con S1000D y gestionas diferentes configuraciones (p.ej., varios modelos de avión), puedes añadir secciones de applicability en cada archivo. Luego, un generador de documentación podría filtrar o compilar solo las secciones aplicables.
+
+3. **Publicación en un Portal Web:**  
+   Convertir estos Markdown a HTML de forma automatizada (por ejemplo, con MkDocs, Docusaurus, o similares) para que los mecánicos e ingenieros tengan un portal navegable.
+
+4. **Inclusión de Ilustraciones:**  
+   Incrustar imágenes (formatos SVG/PNG) dentro de cada archivo Markdown para ilustrar sistemas, componentes o diagramas de procesos de mantenimiento.
+
+**¡Listo!** Con esta propuesta, tu documentación del **ATA 32** (Tren de Aterrizaje) y las secciones auxiliares (FIN, CSN, Consumibles) estarán más ordenadas, siguiendo un **estándar** claro, modular y escalable. Es un paso intermedio entre documentación simple y un entorno de producción S1000D completo, aprovechando la **flexibilidad de Markdown** y la **organización lógica** según la filosofía ATA.

--- a/docs/Anexos.md
+++ b/docs/Anexos.md
@@ -1,0 +1,36 @@
+# Anexos
+
+## Planos y Diagramas de Flujo
+
+1. **Planos del Tren de Aterrizaje:**
+   - [Plano General del Tren de Aterrizaje](./planos/Plano_General_Tren_de_Aterrizaje.pdf)
+   - [Diagrama de Flujo del Sistema Hidráulico](./planos/Diagrama_Flujo_Sistema_Hidraulico.pdf)
+
+2. **Diagramas de Cableado:**
+   - [Diagrama de Cableado del Sistema de Control](./planos/Diagrama_Cableado_Sistema_Control.pdf)
+   - [Diagrama de Cableado del Sistema de Frenado](./planos/Diagrama_Cableado_Sistema_Frenado.pdf)
+
+## Tablas de Torque o Apriete
+
+1. **Tabla de Torque para Tornillos del Tren de Aterrizaje:**
+   - [Tabla de Torque](./tablas/Torque_Tornillos_Tren_de_Aterrizaje.pdf)
+
+2. **Tabla de Apriete para Conexiones Hidráulicas:**
+   - [Tabla de Apriete](./tablas/Apriete_Conexiones_Hidraulicas.pdf)
+
+## Guías de Interpretación de Alarmas Específicas
+
+1. **Guía de Interpretación de Alarmas del Sistema de Control:**
+   - [Guía de Alarmas](./guias/Guia_Alarmas_Sistema_Control.pdf)
+
+2. **Guía de Interpretación de Alarmas del Sistema de Frenado:**
+   - [Guía de Alarmas](./guias/Guia_Alarmas_Sistema_Frenado.pdf)
+
+## Documentación Complementaria
+
+1. **Instrucciones de Servicio:**
+   - [Instrucciones de Servicio del Tren de Aterrizaje](./documentacion/Instrucciones_Servicio_Tren_de_Aterrizaje.pdf)
+
+2. **Boletines de Servicio:**
+   - [Boletín de Servicio 001](./documentacion/Boletin_Servicio_001.pdf)
+   - [Boletín de Servicio 002](./documentacion/Boletin_Servicio_002.pdf)

--- a/docs/Consumibles_y_Expendables.md
+++ b/docs/Consumibles_y_Expendables.md
@@ -1,0 +1,41 @@
+# Consumibles y Expendables
+
+## Lista de Consumibles
+
+1. **Aceites:**
+   - **Descripción:** Aceites utilizados en el sistema hidráulico y de lubricación.
+   - **Fabricante:** HydroLubricants.
+   - **Intervalo de Reemplazo:** Cada 6 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.
+
+2. **Grasas:**
+   - **Descripción:** Grasas utilizadas para lubricar los componentes móviles.
+   - **Fabricante:** LubeTech.
+   - **Intervalo de Reemplazo:** Cada 3 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.
+
+3. **Sellantes:**
+   - **Descripción:** Sellantes utilizados para asegurar la estanqueidad de los componentes.
+   - **Fabricante:** SealSystems Ltd.
+   - **Intervalo de Reemplazo:** Cada 12 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.
+
+## Lista de Expendables
+
+1. **Filtros:**
+   - **Descripción:** Filtros utilizados para mantener la limpieza del sistema hidráulico.
+   - **Fabricante:** FilterTech.
+   - **Intervalo de Reemplazo:** Cada 6 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.
+
+2. **Juntas Tóricas:**
+   - **Descripción:** Juntas utilizadas para asegurar la estanqueidad de los componentes hidráulicos.
+   - **Fabricante:** SealSystems Ltd.
+   - **Intervalo de Reemplazo:** Cada 12 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.
+
+3. **Tornillos de Seguridad:**
+   - **Descripción:** Tornillos utilizados para asegurar los componentes.
+   - **Fabricante:** FastenTech.
+   - **Intervalo de Reemplazo:** Cada 24 meses.
+   - **Método de Descarte:** Reciclaje según las normativas locales.

--- a/docs/Estructura_de_Numeracion_ATA.md
+++ b/docs/Estructura_de_Numeracion_ATA.md
@@ -1,0 +1,73 @@
+# Estructura de Numeración ATA
+
+## Descripción de la Metodología ATA
+
+La metodología ATA (Air Transport Association) es un estándar ampliamente utilizado en la industria aeronáutica para la organización y numeración de la documentación técnica. Este sistema proporciona una estructura clara y coherente que facilita la identificación y el acceso a la información técnica relacionada con el mantenimiento y la operación de aeronaves.
+
+### Capítulo, Sección, Sub-Sección
+
+La estructura de numeración ATA se organiza en tres niveles principales: capítulo, sección y sub-sección. Cada nivel se identifica mediante un código numérico específico que indica su posición dentro de la jerarquía de la documentación.
+
+1. **Capítulo:**
+   - Representa una categoría principal de sistemas o componentes de la aeronave.
+   - Ejemplo: Capítulo 32 - Tren de Aterrizaje.
+
+2. **Sección:**
+   - Subdivisión del capítulo que agrupa información más específica sobre un sistema o componente.
+   - Ejemplo: Sección 32-10 - Tren de Aterrizaje Principal y Puertas.
+
+3. **Sub-Sección:**
+   - Nivel más detallado que proporciona información específica sobre un componente o procedimiento.
+   - Ejemplo: Sub-Sección 32-10-00 - Descripción del Tren de Aterrizaje Principal.
+
+## Convenciones para Numerar Secciones Específicas de Tren de Aterrizaje
+
+Para el sistema de tren de aterrizaje, se utilizan las siguientes convenciones de numeración:
+
+1. **32-00-00 Tren de Aterrizaje (General):**
+   - Descripción global del sistema de tren de aterrizaje.
+   - Identificación de componentes principales.
+
+2. **32-10-00 Tren de Aterrizaje Principal y Puertas:**
+   - Descripción detallada del tren principal (MLG).
+   - Mantenimiento, inspección, partes y referencias.
+
+3. **32-20-00 Tren de Aterrizaje de Nariz:**
+   - Descripción del Nose Landing Gear (NLG).
+   - Procedimientos de inspección y correctivo.
+
+4. **32-30-00 Sistemas de Control del Tren de Aterrizaje:**
+   - Mecanismos y sensores de control.
+   - Interfaz con cockpit y circuitos electrónicos.
+
+5. **32-40-00 Sistema de Frenado del Tren de Aterrizaje:**
+   - Frenos, discos, actuadores hidráulicos, monitoreo de desgaste.
+   - Programas de mantenimiento y pruebas funcionales.
+
+6. **32-50-00 Sistema de Retracción del Tren de Aterrizaje:**
+   - Bomba hidráulica, brazos de retracción, secuencia de retracción.
+   - Procedimientos de ajuste y calibración.
+
+7. **32-60-00 Puertas del Tren de Aterrizaje:**
+   - Tipos de puertas (principal, nariz), bisagras, actuadores.
+   - Ajustes, tolerancias, alineación.
+
+8. **32-70-00 Indicadores y Sistemas de Alerta del Tren de Aterrizaje:**
+   - Luces de tren, alarmas, señales de posición.
+   - Diagnóstico y resolución de fallos en alertas.
+
+9. **32-80-00 Sistemas Hidráulicos para el Tren de Aterrizaje:**
+   - Líneas y válvulas hidráulicas dedicadas al tren.
+   - Depósitos, purga y mantenimiento de fluidos.
+
+10. **32-90-00 Sistemas de Lubricación del Tren de Aterrizaje:**
+    - Puntos de lubricación, tipos de lubricantes, intervalos.
+    - Prácticas estándar para reducir desgaste.
+
+11. **32-100-00 Sistemas de Respaldo y Emergencia del Tren de Aterrizaje:**
+    - Mecanismos de liberación emergente.
+    - Procedimientos en caso de fallo hidráulico.
+
+12. **32-110-00 FIN, Consumibles y Expendables:**
+    - Functional Item Numbers (FIN), partes de uso único o consumibles.
+    - Identificación de repuestos y documentación de inventario.

--- a/docs/Gestion_de_CSN.md
+++ b/docs/Gestion_de_CSN.md
@@ -1,0 +1,73 @@
+# Gestión de CSN (Catalogue Serial Numbers)
+
+## Estructura de Numeración para Ítems Seriados
+
+La gestión de los Números de Serie del Catálogo (CSN) es esencial para el seguimiento y la trazabilidad de los componentes y subcomponentes a lo largo de su ciclo de vida. La estructura de numeración para ítems seriados debe ser clara, consistente y permitir una identificación única de cada ítem.
+
+### Formato de Numeración
+
+El formato de numeración de los CSN debe seguir una convención estándar que incluya información relevante sobre el ítem, como el tipo de componente, el fabricante, el lote de producción y un número de serie único. Un ejemplo de formato de numeración podría ser el siguiente:
+
+```
+[Tipo de Componente]-[Código de Fabricante]-[Lote de Producción]-[Número de Serie Único]
+```
+
+#### Ejemplo:
+
+```
+MLG-ABC-202301-0001
+```
+
+- **MLG:** Tipo de componente (Main Landing Gear)
+- **ABC:** Código de fabricante
+- **202301:** Lote de producción (Enero 2023)
+- **0001:** Número de serie único
+
+## Rastreo de Componentes y Subcomponentes en el Ciclo de Vida
+
+El rastreo de componentes y subcomponentes es crucial para garantizar la calidad, seguridad y cumplimiento normativo de la aeronave. A continuación se describen los pasos y herramientas recomendadas para el rastreo efectivo de los CSN.
+
+### Pasos para el Rastreo de CSN
+
+1. **Asignación de CSN:**
+   - Asignar un CSN único a cada componente y subcomponente durante la fase de producción.
+   - Registrar el CSN en la base de datos de gestión de componentes.
+
+2. **Registro de Información:**
+   - Registrar información detallada sobre cada ítem, incluyendo especificaciones técnicas, historial de mantenimiento, y eventos significativos (reparaciones, reemplazos, etc.).
+   - Utilizar un sistema de gestión de datos (CSDB) para almacenar y organizar esta información.
+
+3. **Monitoreo y Actualización:**
+   - Monitorear el estado y ubicación de cada ítem a lo largo de su ciclo de vida.
+   - Actualizar la base de datos con cualquier cambio en el estado del ítem (mantenimiento, inspección, etc.).
+
+4. **Auditorías y Verificación:**
+   - Realizar auditorías periódicas para verificar la precisión y completitud de los registros de CSN.
+   - Utilizar herramientas de verificación, como escáneres de códigos de barras o RFID, para facilitar el proceso de auditoría.
+
+### Herramientas Recomendadas
+
+1. **Sistema de Gestión de Datos de Componentes (CSDB):**
+   - Un CSDB es una base de datos centralizada que permite el almacenamiento, organización y acceso a la información de los componentes y subcomponentes.
+   - Debe ser capaz de manejar grandes volúmenes de datos y proporcionar funcionalidades de búsqueda y filtrado avanzadas.
+
+2. **Tecnología de Identificación por Radiofrecuencia (RFID):**
+   - Los sistemas RFID permiten la identificación y rastreo automático de componentes mediante etiquetas RFID.
+   - Proporcionan una solución eficiente y precisa para el monitoreo de ítems en tiempo real.
+
+3. **Escáneres de Códigos de Barras:**
+   - Los escáneres de códigos de barras son herramientas útiles para la verificación rápida y precisa de los CSN.
+   - Pueden integrarse con el CSDB para actualizar automáticamente los registros de los ítems.
+
+## Beneficios de una Gestión Eficiente de CSN
+
+Una gestión eficiente de los CSN proporciona numerosos beneficios, incluyendo:
+
+- **Mejora de la Trazabilidad:** Permite un seguimiento preciso de los componentes y subcomponentes a lo largo de su ciclo de vida.
+- **Aumento de la Seguridad:** Facilita la identificación rápida de ítems defectuosos o que requieren mantenimiento.
+- **Cumplimiento Normativo:** Asegura que la aeronave cumpla con las regulaciones y estándares de la industria.
+- **Optimización del Mantenimiento:** Proporciona información detallada sobre el historial de mantenimiento de cada ítem, lo que permite una planificación y ejecución más eficiente del mantenimiento.
+
+## Conclusión
+
+La gestión de los Números de Serie del Catálogo (CSN) es una parte fundamental de la gestión de componentes en la industria aeronáutica. Una estructura de numeración clara y un sistema de rastreo eficiente son esenciales para garantizar la calidad, seguridad y cumplimiento normativo de la aeronave. Al implementar las mejores prácticas y herramientas recomendadas, las organizaciones pueden mejorar significativamente la trazabilidad y gestión de sus componentes y subcomponentes.

--- a/docs/Gestion_de_FIN.md
+++ b/docs/Gestion_de_FIN.md
@@ -1,0 +1,71 @@
+# Gestión de FIN (Functional Instrument Numbers)
+
+## Asignación de FIN a Cada Subsistema
+
+La gestión de los Números de Instrumento Funcional (FIN) es crucial para la identificación y seguimiento de los subsistemas de la aeronave. La asignación de FIN a cada subsistema debe ser clara, consistente y permitir una identificación única de cada ítem.
+
+### Formato de Numeración
+
+El formato de numeración de los FIN debe seguir una convención estándar que incluya información relevante sobre el ítem, como el tipo de subsistema, el fabricante, el lote de producción y un número de serie único. Un ejemplo de formato de numeración podría ser el siguiente:
+
+```
+[Tipo de Subsistema]-[Código de Fabricante]-[Lote de Producción]-[Número de Serie Único]
+```
+
+#### Ejemplo:
+
+```
+NLG-ABC-202301-0001
+```
+
+- **NLG:** Tipo de subsistema (Nose Landing Gear)
+- **ABC:** Código de fabricante
+- **202301:** Lote de producción (Enero 2023)
+- **0001:** Número de serie único
+
+## Interacción con la CSDB y el DMRL
+
+La interacción con la Base de Datos de Gestión de Componentes (CSDB) y la Lista de Materiales de Referencia de Diseño (DMRL) es esencial para garantizar la trazabilidad y el cumplimiento normativo de los subsistemas de la aeronave.
+
+### Base de Datos de Gestión de Componentes (CSDB)
+
+La CSDB es una base de datos centralizada que permite el almacenamiento, organización y acceso a la información de los subsistemas. Debe ser capaz de manejar grandes volúmenes de datos y proporcionar funcionalidades de búsqueda y filtrado avanzadas.
+
+#### Funcionalidades Clave de la CSDB
+
+1. **Almacenamiento de Datos:**
+   - Almacenar información detallada sobre cada subsistema, incluyendo especificaciones técnicas, historial de mantenimiento y eventos significativos (reparaciones, reemplazos, etc.).
+
+2. **Organización de Datos:**
+   - Organizar los datos de manera lógica y estructurada para facilitar el acceso y la gestión.
+
+3. **Búsqueda y Filtrado:**
+   - Proporcionar herramientas de búsqueda y filtrado avanzadas para encontrar rápidamente la información necesaria.
+
+### Lista de Materiales de Referencia de Diseño (DMRL)
+
+La DMRL es una lista de materiales que incluye todos los componentes y subsistemas necesarios para el diseño y fabricación de la aeronave. La interacción con la DMRL es crucial para asegurar que todos los subsistemas estén correctamente documentados y cumplan con los requisitos de diseño.
+
+#### Funcionalidades Clave de la DMRL
+
+1. **Documentación de Componentes:**
+   - Documentar todos los componentes y subsistemas necesarios para el diseño y fabricación de la aeronave.
+
+2. **Cumplimiento de Requisitos:**
+   - Asegurar que todos los componentes y subsistemas cumplan con los requisitos de diseño y normativos.
+
+3. **Actualización Continua:**
+   - Mantener la DMRL actualizada con cualquier cambio en el diseño o fabricación de la aeronave.
+
+## Beneficios de una Gestión Eficiente de FIN
+
+Una gestión eficiente de los FIN proporciona numerosos beneficios, incluyendo:
+
+- **Mejora de la Trazabilidad:** Permite un seguimiento preciso de los subsistemas a lo largo de su ciclo de vida.
+- **Aumento de la Seguridad:** Facilita la identificación rápida de ítems defectuosos o que requieren mantenimiento.
+- **Cumplimiento Normativo:** Asegura que la aeronave cumpla con las regulaciones y estándares de la industria.
+- **Optimización del Mantenimiento:** Proporciona información detallada sobre el historial de mantenimiento de cada ítem, lo que permite una planificación y ejecución más eficiente del mantenimiento.
+
+## Conclusión
+
+La gestión de los Números de Instrumento Funcional (FIN) es una parte fundamental de la gestión de subsistemas en la industria aeronáutica. Una estructura de numeración clara y un sistema de rastreo eficiente son esenciales para garantizar la calidad, seguridad y cumplimiento normativo de la aeronave. Al implementar las mejores prácticas y herramientas recomendadas, las organizaciones pueden mejorar significativamente la trazabilidad y gestión de sus subsistemas.

--- a/docs/Indice_Completo.md
+++ b/docs/Indice_Completo.md
@@ -1,0 +1,40 @@
+# Índice Completo
+
+## Capítulo 32 - Tren de Aterrizaje
+
+- [**32-00-00** Tren de Aterrizaje (General)](./32-00-00_Tren_de_Aterrizaje.md)
+  - Descripción global del sistema de Tren de Aterrizaje
+  - Identificación de componentes principales
+- [**32-10-00** Tren de Aterrizaje Principal y Puertas](./32-10-00_Tren_de_Aterrizaje_Principal_y_Puertas.md)
+  - Descripción detallada del tren principal (MLG)
+  - Mantenimiento, inspección, partes y referencias
+- [**32-20-00** Tren de Aterrizaje de Nariz](./32-20-00_Tren_de_Aterrizaje_de_Nariz.md)
+  - Descripción del Nose Landing Gear (NLG)
+  - Procedimientos de inspección y correctivo
+- [**32-30-00** Sistemas de Control del Tren de Aterrizaje](./32-30-00_Sistemas_de_Control_del_Tren_de_Aterrizaje.md)
+  - Mecanismos y sensores de control
+  - Interfaz con cockpit y circuitos electrónicos
+- [**32-40-00** Sistema de Frenado del Tren de Aterrizaje](./32-40-00_Sistema_de_Frenado_del_Tren_de_Aterrizaje.md)
+  - Frenos, discos, actuadores hidráulicos, monitoreo de desgaste
+  - Programas de mantenimiento y pruebas funcionales
+- [**32-50-00** Sistema de Retracción del Tren de Aterrizaje](./32-50-00_Sistema_de_Retraccion_del_Tren_de_Aterrizaje.md)
+  - Bomba hidráulica, brazos de retracción, secuencia de retracción
+  - Procedimientos de ajuste y calibración
+- [**32-60-00** Puertas del Tren de Aterrizaje](./32-60-00_Puertas_del_Tren_de_Aterrizaje.md)
+  - Tipos de puertas (principal, nariz), bisagras, actuadores
+  - Ajustes, tolerancias, alineación
+- [**32-70-00** Indicadores y Sistemas de Alerta del Tren de Aterrizaje](./32-70-00_Indicadores_y_Sistemas_de_Alerta_del_Tren_de_Aterrizaje.md)
+  - LUCES de tren, alarmas, señales de posición
+  - Diagnóstico y resolución de fallos en alertas
+- [**32-80-00** Sistemas Hidráulicos para el Tren de Aterrizaje](./32-80-00_Sistemas_Hidraulicos_para_el_Tren_de_Aterrizaje.md)
+  - Líneas y válvulas hidráulicas dedicadas al tren
+  - Depósitos, purga y mantenimiento de fluidos
+- [**32-90-00** Sistemas de Lubricación del Tren de Aterrizaje](./32-90-00_Sistemas_de_Lubricacion_del_Tren_de_Aterrizaje.md)
+  - Puntos de lubricación, tipos de lubricantes, intervalos
+  - Prácticas estándar para reducir desgaste
+- [**32-100-00** Sistemas de Respaldo y Emergencia del Tren de Aterrizaje](./32-100-00_Sistemas_de_Respaldo_y_Emergencia_del_Tren_de_Aterrizaje.md)
+  - Mecanismos de liberación emergente
+  - Procedimientos en caso de fallo hidráulico
+- [**32-110-00** FIN, Consumibles y Expendables](./32-110-00_FIN_Consumibles_y_Expendables.md)
+  - Functional Item Numbers (FIN), partes de uso único o consumibles
+  - Identificación de repuestos, documentación de inventario

--- a/docs/Introduccion.md
+++ b/docs/Introduccion.md
@@ -1,0 +1,17 @@
+# Introducción
+
+## Alcance General del Documento
+
+Este documento proporciona una descripción detallada del sistema de tren de aterrizaje del AMPEL360XWLRGA, incluyendo sus componentes principales, procedimientos de mantenimiento, y medidas de seguridad. Está diseñado para ser una guía completa para ingenieros y técnicos que trabajan en el mantenimiento y operación del tren de aterrizaje.
+
+## Convenciones de Uso y Referencias Normativas
+
+Este documento sigue las convenciones y estándares establecidos por S1000D y ATA iSpec 2200. Las secciones están numeradas de acuerdo con la estructura de numeración ATA, lo que facilita la referencia cruzada y la integración con otros documentos técnicos.
+
+## Definiciones, Abreviaturas, Siglas
+
+- **ATA:** Air Transport Association
+- **S1000D:** International specification for technical publications using a common source database
+- **MLG:** Main Landing Gear (Tren de Aterrizaje Principal)
+- **NLG:** Nose Landing Gear (Tren de Aterrizaje de Nariz)
+- **EPP:** Equipos de Protección Personal

--- a/docs/Procedimientos_de_Mantenimiento.md
+++ b/docs/Procedimientos_de_Mantenimiento.md
@@ -1,0 +1,161 @@
+# Procedimientos de Mantenimiento
+
+## Mantenimientos Rutinarios
+
+Los mantenimientos rutinarios son esenciales para asegurar el funcionamiento seguro y eficiente del tren de aterrizaje. Estos procedimientos incluyen inspecciones visuales, pruebas funcionales y tareas de limpieza y lubricación.
+
+### Inspecciones Visuales
+
+1. **Inspección de Componentes:**
+   - Verificar la integridad estructural de los componentes del tren de aterrizaje.
+   - Buscar signos de desgaste, corrosión o daños.
+
+2. **Inspección de Conexiones:**
+   - Asegurar que todas las conexiones estén firmes y seguras.
+   - Verificar que no haya fugas de fluidos hidráulicos.
+
+### Pruebas Funcionales
+
+1. **Prueba de Extensión y Retracción:**
+   - Realizar pruebas de extensión y retracción del tren de aterrizaje.
+   - Asegurar que el sistema opere suavemente y sin obstrucciones.
+
+2. **Prueba de Frenado:**
+   - Verificar el funcionamiento de los frenos.
+   - Asegurar que los frenos proporcionen la capacidad de frenado necesaria.
+
+### Limpieza y Lubricación
+
+1. **Limpieza de Componentes:**
+   - Limpiar los componentes del tren de aterrizaje para remover suciedad y residuos.
+   - Utilizar productos de limpieza aprobados para evitar daños.
+
+2. **Lubricación de Puntos Críticos:**
+   - Aplicar lubricantes adecuados a los puntos críticos del tren de aterrizaje.
+   - Asegurar que la lubricación sea uniforme y suficiente.
+
+## Mantenimientos Preventivos
+
+Los mantenimientos preventivos son realizados para prevenir fallos y prolongar la vida útil de los componentes del tren de aterrizaje. Estos procedimientos incluyen reemplazo de componentes, ajustes y calibraciones.
+
+### Reemplazo de Componentes
+
+1. **Reemplazo de Neumáticos:**
+   - Sustituir neumáticos desgastados según el programa de mantenimiento.
+   - Verificar la presión de los neumáticos después del reemplazo.
+
+2. **Reemplazo de Discos de Freno:**
+   - Sustituir discos de freno desgastados.
+   - Verificar el funcionamiento de los frenos después del reemplazo.
+
+### Ajustes y Calibraciones
+
+1. **Ajuste de la Presión Hidráulica:**
+   - Verificar y ajustar la presión hidráulica del sistema.
+   - Asegurar que la presión esté dentro de los límites operativos especificados.
+
+2. **Calibración de Sensores:**
+   - Verificar y calibrar los sensores de posición y presión.
+   - Asegurar que los sensores proporcionen lecturas precisas y fiables.
+
+## Mantenimientos Correctivos
+
+Los mantenimientos correctivos son realizados para corregir fallos o problemas identificados durante las inspecciones o pruebas funcionales. Estos procedimientos incluyen reparaciones, reemplazos y ajustes necesarios.
+
+### Reparaciones
+
+1. **Reparación de Componentes Dañados:**
+   - Reparar componentes dañados o desgastados.
+   - Aplicar parches y refuerzos según sea necesario.
+
+2. **Reparación de Fugas Hidráulicas:**
+   - Identificar y reparar fugas en el sistema hidráulico.
+   - Verificar el funcionamiento del sistema después de la reparación.
+
+### Reemplazos
+
+1. **Reemplazo de Actuadores Hidráulicos:**
+   - Sustituir actuadores hidráulicos defectuosos.
+   - Verificar el funcionamiento del sistema después del reemplazo.
+
+2. **Reemplazo de Sensores:**
+   - Sustituir sensores defectuosos.
+   - Calibrar los nuevos sensores para asegurar lecturas precisas.
+
+### Ajustes
+
+1. **Ajuste de la Alineación del Tren de Aterrizaje:**
+   - Verificar y ajustar la alineación del tren de aterrizaje.
+   - Asegurar que el tren de aterrizaje esté correctamente alineado para un funcionamiento seguro.
+
+2. **Ajuste de los Sistemas de Cierre y Sellado:**
+   - Verificar y ajustar los sistemas de cierre y sellado de las puertas del tren de aterrizaje.
+   - Asegurar que las puertas se cierren herméticamente para mejorar la aerodinámica.
+
+## Checklists y Secuencias de Inspección
+
+Las checklists y secuencias de inspección son herramientas esenciales para asegurar que todos los procedimientos de mantenimiento se realicen de manera completa y precisa. Estas listas incluyen todos los pasos necesarios para cada tipo de mantenimiento.
+
+### Checklist de Inspección Visual
+
+1. **Verificación de Componentes:**
+   - [ ] Inspeccionar la integridad estructural de los componentes.
+   - [ ] Verificar conexiones y buscar fugas.
+
+2. **Verificación de Neumáticos:**
+   - [ ] Inspeccionar el desgaste de los neumáticos.
+   - [ ] Verificar la presión de los neumáticos.
+
+### Checklist de Pruebas Funcionales
+
+1. **Prueba de Extensión y Retracción:**
+   - [ ] Realizar prueba de extensión y retracción.
+   - [ ] Verificar operación suave y sin obstrucciones.
+
+2. **Prueba de Frenado:**
+   - [ ] Verificar funcionamiento de los frenos.
+   - [ ] Asegurar capacidad de frenado adecuada.
+
+### Secuencia de Inspección de Mantenimiento Preventivo
+
+1. **Reemplazo de Componentes:**
+   - [ ] Sustituir neumáticos desgastados.
+   - [ ] Reemplazar discos de freno desgastados.
+
+2. **Ajustes y Calibraciones:**
+   - [ ] Ajustar presión hidráulica.
+   - [ ] Calibrar sensores de posición y presión.
+
+## Referencias Cruzadas a Data Modules S1000D
+
+Los procedimientos de mantenimiento están documentados en módulos de datos S1000D, que proporcionan información detallada y estructurada sobre cada tarea de mantenimiento. A continuación se presentan las referencias cruzadas a los módulos de datos relevantes.
+
+### Módulos de Mantenimiento
+
+1. **Módulo de Inspección Visual:**
+   - DMC: 32-00-00-00-00A-000A-D
+   - Descripción: Inspección visual de componentes del tren de aterrizaje.
+
+2. **Módulo de Pruebas Funcionales:**
+   - DMC: 32-00-00-00-00A-000A-M
+   - Descripción: Pruebas funcionales del sistema de tren de aterrizaje.
+
+### Módulos de Reemplazo de Componentes
+
+1. **Módulo de Reemplazo de Neumáticos:**
+   - DMC: 32-10-00-00-00A-000A-R
+   - Descripción: Procedimientos para el reemplazo de neumáticos del tren de aterrizaje.
+
+2. **Módulo de Reemplazo de Discos de Freno:**
+   - DMC: 32-40-00-00-00A-000A-R
+   - Descripción: Procedimientos para el reemplazo de discos de freno del tren de aterrizaje.
+
+### Módulos de Ajustes y Calibraciones
+
+1. **Módulo de Ajuste de Presión Hidráulica:**
+   - DMC: 32-50-00-00-00A-000A-A
+   - Descripción: Procedimientos para el ajuste de la presión hidráulica del sistema de tren de aterrizaje.
+
+2. **Módulo de Calibración de Sensores:**
+   - DMC: 32-30-00-00-00A-000A-C
+   - Descripción: Procedimientos para la calibración de sensores de posición y presión del tren de aterrizaje.

--- a/docs/Seguridad_y_Precauciones.md
+++ b/docs/Seguridad_y_Precauciones.md
@@ -1,0 +1,71 @@
+# Seguridad y Precauciones
+
+## Reglas Generales de Seguridad en Línea de Vuelo y Hangar
+
+1. **Uso de EPP (Equipos de Protección Personal):**
+   - Siempre use el equipo de protección personal adecuado, incluyendo casco, gafas de seguridad, guantes y calzado de seguridad.
+   - Asegúrese de que el EPP esté en buen estado y sea el adecuado para la tarea que se va a realizar.
+
+2. **Zonas de Trabajo Seguras:**
+   - Mantenga las áreas de trabajo limpias y libres de obstáculos.
+   - Señalice adecuadamente las zonas peligrosas y asegúrese de que solo el personal autorizado tenga acceso.
+
+3. **Manipulación de Herramientas y Equipos:**
+   - Utilice las herramientas y equipos de manera correcta y segura.
+   - Realice inspecciones regulares de las herramientas y equipos para asegurarse de que estén en buen estado.
+
+4. **Procedimientos de Emergencia:**
+   - Familiarícese con los procedimientos de emergencia y las rutas de evacuación.
+   - Conozca la ubicación de los equipos de emergencia, como extintores y botiquines de primeros auxilios.
+
+## Precauciones Específicas para la Manipulación del Tren de Aterrizaje
+
+1. **Inspección Visual:**
+   - Realice una inspección visual completa del tren de aterrizaje antes de cualquier operación.
+   - Verifique que no haya daños visibles, fugas de fluidos o componentes sueltos.
+
+2. **Uso de Soportes y Bloqueos:**
+   - Asegúrese de que el tren de aterrizaje esté adecuadamente soportado y bloqueado antes de realizar cualquier trabajo.
+   - Utilice soportes y bloqueos aprobados y verifique que estén en buen estado.
+
+3. **Manipulación de Componentes Pesados:**
+   - Utilice equipos de elevación adecuados para manipular componentes pesados del tren de aterrizaje.
+   - Nunca intente levantar o mover componentes pesados sin la ayuda de equipos de elevación.
+
+4. **Seguridad en el Uso de Herramientas:**
+   - Utilice herramientas adecuadas y en buen estado para trabajar en el tren de aterrizaje.
+   - Asegúrese de que las herramientas estén calibradas y sean las correctas para la tarea específica.
+
+## EPP (Equipos de Protección Personal) Requeridos
+
+1. **Casco de Seguridad:**
+   - Protege la cabeza de impactos y caídas de objetos.
+   - Debe cumplir con las normativas de seguridad vigentes.
+
+2. **Gafas de Seguridad:**
+   - Protegen los ojos de partículas, polvo y salpicaduras de líquidos.
+   - Deben ser cómodas y ajustarse adecuadamente al rostro.
+
+3. **Guantes de Protección:**
+   - Protegen las manos de cortes, abrasiones y productos químicos.
+   - Deben ser resistentes y adecuados para la tarea específica.
+
+4. **Calzado de Seguridad:**
+   - Protege los pies de impactos, perforaciones y resbalones.
+   - Debe tener puntera de acero y suela antideslizante.
+
+5. **Protección Auditiva:**
+   - Protege los oídos de ruidos fuertes y prolongados.
+   - Debe ser cómoda y ajustarse adecuadamente.
+
+6. **Ropa de Trabajo:**
+   - Debe ser resistente y adecuada para el entorno de trabajo.
+   - Debe estar en buen estado y sin partes sueltas que puedan engancharse en maquinaria.
+
+7. **Arnés de Seguridad:**
+   - Utilizado para trabajos en altura.
+   - Debe estar en buen estado y ser adecuado para la tarea específica.
+
+## Conclusión
+
+La seguridad es una prioridad en todas las operaciones relacionadas con el tren de aterrizaje. Siguiendo estas reglas y precauciones, se puede minimizar el riesgo de accidentes y garantizar un entorno de trabajo seguro para todos los involucrados.


### PR DESCRIPTION
Add ATA chapter-based documentation for the Landing Gear (ATA 32) domain.

* **Documentation Files:**
  - Create `docs/ATA.md` as the main index for the ATA chapter-based documentation.
  - Add `docs/32-00-00_Tren_de_Aterrizaje.md` for general landing gear documentation.
  - Add `docs/32-10-00_Tren_de_Aterrizaje_Principal_y_Puertas.md` for main landing gear and doors documentation.
  - Add `docs/32-20-00_Tren_de_Aterrizaje_de_Nariz.md` for nose landing gear documentation.
  - Add `docs/32-30-00_Sistemas_de_Control_del_Tren_de_Aterrizaje.md` for landing gear control systems documentation.
  - Add `docs/32-40-00_Sistema_de_Frenado_del_Tren_de_Aterrizaje.md` for landing gear braking system documentation.

* **Issue Template:**
  - Update `.github/ISSUE_TEMPLATE.md` to include sections for the new ATA chapter-based layout.
  - Add instructions for creating issues related to specific ATA chapters.

* **Deployment Workflow:**
  - Update `.github/workflows/deploy-docs.yml` to include steps for deploying the new ATA chapter-based documentation.
  - Ensure the workflow builds and deploys the documentation to GitHub Pages.

* **Application Routes:**
  - Update `app.py` to include routes for the new ATA chapter-based documentation.
  - Add logic to serve the new documentation files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Robbbo-T/Ampel360XWLRGA?shareId=XXXX-XXXX-XXXX-XXXX).